### PR TITLE
Update top level init

### DIFF
--- a/src/glasflow/__init__.py
+++ b/src/glasflow/__init__.py
@@ -9,7 +9,10 @@ Code is hosted at: https://github.com/igr-ml/glasflow
 
 nflows: https://github.com/bayesiains/nflows
 """
-from .flows import CouplingNSF, RealNVP
+from .flows import (
+    CouplingNSF,
+    RealNVP,
+)
 
 try:
     from importlib.metadata import version, PackageNotFoundError


### PR DESCRIPTION
This improves the top-level init file. The main change is to allow importing the flows from the top-level package:

```python
from glasflow import RealNVP
```

Also when calling `from glasflow import *` only the flows are returned.