### PR TITLE
Update urls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "submodules/nflows"]
 	path = submodules/nflows
-	url = https://github.com/igr-ml/nflows.git
+	url = https://github.com/uofgravity/nflows.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Another patch to fix CI not uploading release to PyPI
 ### Changed
 
-- Update `nflows` submodule ([#36](https://github.com/igr-ml/glasflow/pull/36))
-- Remove LFS from `publish-to-pypi` workflow ([#36](https://github.com/igr-ml/glasflow/pull/36))
+- Update `nflows` submodule ([#36](https://github.com/uofgravity/glasflow/pull/36))
+- Remove LFS from `publish-to-pypi` workflow ([#36](https://github.com/uofgravity/glasflow/pull/36))
 
 ## [0.1.1]
 
@@ -21,7 +21,7 @@ Patch to fix CI not uploading release to PyPI
 
 ### Changed
 
-- Add LFS to `publish-to-pypi` workflow  ([#35](https://github.com/igr-ml/glasflow/pull/35))
+- Add LFS to `publish-to-pypi` workflow  ([#35](https://github.com/uofgravity/glasflow/pull/35))
 
 ## [0.1.0]
 
@@ -32,7 +32,7 @@ Patch to fix CI not uploading release to PyPI
 - Add `nflows` submodule that replaces `nflows` dependency
 - Add option for user-defined masks in coupling-based flows
 
-[Unreleased]: https://github.com/igr-ml/glasflow/compare/v0.1.2...HEAD
-[0.1.2]: https://github.com/igr-ml/glasflow/compare/v0.1.1...v0.1.2
-[0.1.1]: https://github.com/igr-ml/glasflow/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/igr-ml/glasflow/releases/tag/v0.1.0
+[Unreleased]: https://github.com/uofgravity/glasflow/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/uofgravity/glasflow/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/uofgravity/glasflow/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/uofgravity/glasflow/releases/tag/v0.1.0

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -24,7 +24,7 @@ SOFTWARE.
 
 # nflows 
 
-This software includes a fork of [nflows](https://github.com/igr-ml/nflows)
+This software includes a fork of [nflows](https://github.com/uofgravity/nflows)
 which is licensed under an MIT License:
 
 MIT License

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ flow = RealNVP(
 )
 ```
 
-Please see [glasflow/examples](https://github.com/igr-ml/glasflow/tree/main/examples) for a typical training regime example.
+Please see [glasflow/examples](https://github.com/uofgravity/glasflow/tree/main/examples) for a typical training regime example.
 
 ## nflows
 
@@ -68,8 +68,8 @@ After setting this variable `glasflow.nflows` will point to the version of nflow
 
 ## Contributing
 
-Pull requests are welcome. You can review the contribution guidelines [here](https://github.com/igr-ml/glasflow/blob/main/CONTRIBUTING.md). For major changes, please open an issue first to discuss what you would like to change.
+Pull requests are welcome. You can review the contribution guidelines [here](https://github.com/uofgravity/glasflow/blob/main/CONTRIBUTING.md). For major changes, please open an issue first to discuss what you would like to change.
 
 ## Citing
 
-If you use glasflow in your work please cite [our DOI](https://doi.org/10.5281/zenodo.7108558). We also recommend you also cite nflows following the guidelines in the [nflows readme](https://github.com/igr-ml/nflows#citing-nflows).
+If you use glasflow in your work please cite [our DOI](https://doi.org/10.5281/zenodo.7108558). We also recommend you also cite nflows following the guidelines in the [nflows readme](https://github.com/uofgravity/nflows#citing-nflows).

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,9 +3,9 @@ name = glasflow
 description = Normalising flows using nflows
 long_description = file: README.md
 long_description_content_type = text/markdown
-author = IGR-ML
+author = IGR
 author_email = m.williams.4@research.gla.ac.uk
-url = https://github.com/igr-ml/glasflow
+url = https://github.com/uofgravity/glasflow
 license = MIT
 classifiers =
     Programming Language :: Python :: 3.7

--- a/src/glasflow/__init__.py
+++ b/src/glasflow/__init__.py
@@ -5,7 +5,7 @@ glasflow
 
 Implementations of normalising flows in PyTorch based on nflows.
 
-Code is hosted at: https://github.com/igr-ml/glasflow
+Code is hosted at: https://github.com/uofgravity/glasflow
 
 nflows: https://github.com/bayesiains/nflows
 """


### PR DESCRIPTION
Update all of the URLs to point to `uofgravity` instead of `igr-ml`.

We'll also need to update `conda-forge` at some point.