### PR TITLE
Apply black in CI to Jupyter notebooks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with:
+          jupyter: true
           options: "--check --diff"
   flake8:
     name: Flake8


### PR DESCRIPTION
Update the linting CI to apply `black` to the Jupyter notebooks.

Closes https://github.com/uofgravity/glasflow/issues/30