### PR TITLE
Add uniform distribution for spline flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a multi-layer perceptron (`glasflow.nets.mlp.MLP`).
 - Add a resampled Gaussian distribution that uses Learnt Accept/Reject Samples (`glasflow.distributions.resampled.ResampledGaussian`).
 - Add `nessai.utils.get_torch_size`.
+- Add a multivariate uniform distribution (`glasflow.distributions.uniform.MultivariateUniform`)
 
 ## [0.1.2]
 

--- a/src/glasflow/distributions/__init__.py
+++ b/src/glasflow/distributions/__init__.py
@@ -1,7 +1,9 @@
 """Distributions for use with normalising flows"""
 
 from .resampled import ResampledGaussian
+from .uniform import MultivariateUniform
 
 __all__ = [
+    "MultivariateUniform",
     "ResampledGaussian",
 ]

--- a/src/glasflow/distributions/uniform.py
+++ b/src/glasflow/distributions/uniform.py
@@ -47,7 +47,7 @@ class MultivariateUniform(Distribution):
             )
         lb = self.low.le(inputs).type_as(self.low).prod(-1)
         ub = self.high.gt(inputs).type_as(self.low).prod(-1)
-        return torch.log(lb.mul(ub)) - self._log_prob_value
+        return torch.log(lb.mul(ub)) + self._log_prob_value
 
     def _sample(self, num_samples, context):
         if context is not None:

--- a/src/glasflow/distributions/uniform.py
+++ b/src/glasflow/distributions/uniform.py
@@ -31,10 +31,10 @@ class MultivariateUniform(Distribution):
         low, high = map(torch.as_tensor, [low, high])
 
         if low.shape != high.shape:
-            raise ValueError("low and high are not of the same size")
+            raise ValueError("low and high are not the same shape")
 
         if not (low < high).byte().all():
-            raise ValueError("low has elements that are higher than high")
+            raise ValueError("low has elements that are larger than high")
 
         self._shape = low.shape
         self.register_buffer("low", low)

--- a/src/glasflow/distributions/uniform.py
+++ b/src/glasflow/distributions/uniform.py
@@ -1,0 +1,62 @@
+"""
+Multidimensional uniform distribution.
+"""
+from typing import Union
+
+from glasflow.nflows.distributions import Distribution
+import torch
+
+
+class MultivariateUniform(Distribution):
+    def __init__(
+        self, low: Union[torch.Tensor, float], high: Union[torch.Tensor, float]
+    ):
+        """Multivariate uniform distribution defined on a box.
+
+        Based on this implementation: \
+            https://github.com/bayesiains/nflows/pull/17 but with fixes for
+            CUDA support.
+
+        Does not support conditional inputs.
+
+        Parameters
+        -----------
+        low : Union[torch.Tensor, float]
+            Lower range (inclusive).
+        high : Union[torch.Tensor, float]
+            Upper range (exclusive).
+        """
+        super().__init__()
+        if low.shape != high.shape:
+            raise ValueError("low and high are not of the same size")
+
+        if not (low < high).byte().all():
+            raise ValueError("low has elements that are higher than high")
+
+        self._shape = low.shape
+        self.register_buffer("low", low)
+        self.register_buffer("high", high)
+        self.register_buffer(
+            "_log_prob_value", -torch.sum(torch.log(high - low))
+        )
+
+    def _log_prob(self, inputs, context):
+        if context is not None:
+            raise NotImplementedError(
+                "Context is not supported by MultidimensionalUniform!"
+            )
+        lb = self.low.le(inputs).type_as(self.low).prod(-1)
+        ub = self.high.gt(inputs).type_as(self.low).prod(-1)
+        return torch.log(lb.mul(ub)) - self._log_prob_value
+
+    def _sample(self, num_samples, context):
+        if context is not None:
+            raise NotImplementedError(
+                "Context is not supported by MultidimensionalUniform!"
+            )
+        low_expanded = self.low.expand(num_samples, *self._shape)
+        high_expanded = self.high.expand(num_samples, *self._shape)
+        samples = low_expanded + torch.rand(
+            num_samples, *self._shape, device=self.low.device
+        ) * (high_expanded - low_expanded)
+        return samples

--- a/src/glasflow/distributions/uniform.py
+++ b/src/glasflow/distributions/uniform.py
@@ -27,6 +27,9 @@ class MultivariateUniform(Distribution):
             Upper range (exclusive).
         """
         super().__init__()
+
+        low, high = map(torch.as_tensor, [low, high])
+
         if low.shape != high.shape:
             raise ValueError("low and high are not of the same size")
 

--- a/src/glasflow/flows/nsf.py
+++ b/src/glasflow/flows/nsf.py
@@ -7,12 +7,16 @@ See: https://arxiv.org/abs/1906.04032
 from glasflow.nflows.transforms.coupling import (
     PiecewiseRationalQuadraticCouplingTransform,
 )
+import torch
 import torch.nn.functional as F
 from .coupling import CouplingFlow
 
 
 class CouplingNSF(CouplingFlow):
     """Implementation of Neural Spline Flows using a coupling transform.
+
+    Supports use of a uniform distribution for the latent space. This
+    automatically disables the tails and sets the bounds to [0, 1).
 
     Parameters
     ----------
@@ -75,6 +79,18 @@ class CouplingNSF(CouplingFlow):
         **kwargs,
     ):
         transform_class = PiecewiseRationalQuadraticCouplingTransform
+
+        if distribution == "uniform":
+            from ..distributions import MultivariateUniform
+
+            tail_bound = 1.0
+            tail_type = None
+            distribution = MultivariateUniform(
+                low=torch.Tensor(n_inputs * [0.0]),
+                high=torch.Tensor(n_inputs * [1.0]),
+            )
+            batch_norm_between_transforms = False
+
         super().__init__(
             transform_class,
             n_inputs,

--- a/tests/test_distributions/test_uniform.py
+++ b/tests/test_distributions/test_uniform.py
@@ -1,0 +1,84 @@
+"Tests for the Multivariate uniform distribution"
+from unittest.mock import create_autospec
+
+import pytest
+import torch
+
+from glasflow.distributions.uniform import MultivariateUniform
+
+
+@pytest.fixture()
+def dist():
+    return create_autospec(MultivariateUniform)
+
+
+@pytest.mark.parametrize(
+    "low, high", [(0.0, 1.0), (torch.zeros(2), torch.ones(2))]
+)
+def test_init(low, high):
+    """Assert different input types are valid"""
+    dist = MultivariateUniform(low, high)
+    assert dist._log_prob_value is not None
+
+
+def test_init_invalid_shapes():
+    """Assert an error is raised if the shapes are different"""
+    with pytest.raises(ValueError, match=r"low and high are not the same shape"):
+        MultivariateUniform(torch.tensor(0), torch.tensor([1, 1]))
+
+
+def test_init_invalid_bounds():
+    """Assert an error is raised if low !< high"""
+    with pytest.raises(ValueError, match=r"low has elements that are larger than high"):
+        MultivariateUniform(torch.tensor([1, 0]), torch.tensor([1, 1]))
+
+
+@pytest.mark.parametrize(
+    "inputs, target",
+    [
+        (torch.tensor([0.5, 0.5]), -torch.log(torch.tensor(4.0))),
+        (torch.tensor([-1.0, -1.0]), -torch.tensor(torch.inf)),
+        (torch.tensor([-1.0, 0.5]), -torch.tensor(torch.inf)),
+        (
+            torch.tensor([[-1.0, 0.5], [1.0, 1.0]]),
+            torch.log(torch.tensor([0.0, 1.0 / 4.0]))
+        ),
+    ]
+)
+def test_log_prob(dist, inputs, target):
+    """Assert log prob returns the correct value"""
+    dist.low = torch.zeros(2)
+    dist.high = 2 * torch.ones(2)
+    dist._log_prob_value = -torch.log(torch.tensor(4.0))
+
+    out = MultivariateUniform._log_prob(dist, inputs, None)
+    assert torch.equal(out, target)
+
+
+@pytest.mark.parametrize("num_samples", [1, 10])
+def test_sample(dist, num_samples):
+    """Assert the correct number of samples are returned and they're in the
+    correct range.
+    """
+    n_dims = 2
+    dist.low = torch.zeros(n_dims)
+    dist.high = 2 * torch.ones(n_dims)
+    dist._shape = dist.low.shape
+
+    samples = MultivariateUniform._sample(dist, num_samples, None)
+
+    assert samples.shape == (num_samples, n_dims)
+    assert (samples < dist.high).all()
+    assert (samples >= dist.low).all()
+
+
+def test_context_error_log_prob(dist):
+    """Assert an error is raised if log_prob is called and is not None."""
+    with pytest.raises(NotImplementedError, match="Context is not supported by MultidimensionalUniform!"):
+        MultivariateUniform._log_prob(dist, torch.ones(1), torch.ones(1))
+
+
+def test_context_error_sample(dist):
+    """Assert an error is raised if sample is called and context is not None."""
+    with pytest.raises(NotImplementedError, match="Context is not supported by MultidimensionalUniform!"):
+        MultivariateUniform._sample(dist, 10, torch.ones(1))

--- a/tests/test_distributions/test_uniform.py
+++ b/tests/test_distributions/test_uniform.py
@@ -23,13 +23,17 @@ def test_init(low, high):
 
 def test_init_invalid_shapes():
     """Assert an error is raised if the shapes are different"""
-    with pytest.raises(ValueError, match=r"low and high are not the same shape"):
+    with pytest.raises(
+        ValueError, match=r"low and high are not the same shape"
+    ):
         MultivariateUniform(torch.tensor(0), torch.tensor([1, 1]))
 
 
 def test_init_invalid_bounds():
     """Assert an error is raised if low !< high"""
-    with pytest.raises(ValueError, match=r"low has elements that are larger than high"):
+    with pytest.raises(
+        ValueError, match=r"low has elements that are larger than high"
+    ):
         MultivariateUniform(torch.tensor([1, 0]), torch.tensor([1, 1]))
 
 
@@ -41,9 +45,9 @@ def test_init_invalid_bounds():
         (torch.tensor([-1.0, 0.5]), -torch.tensor(torch.inf)),
         (
             torch.tensor([[-1.0, 0.5], [1.0, 1.0]]),
-            torch.log(torch.tensor([0.0, 1.0 / 4.0]))
+            torch.log(torch.tensor([0.0, 1.0 / 4.0])),
         ),
-    ]
+    ],
 )
 def test_log_prob(dist, inputs, target):
     """Assert log prob returns the correct value"""
@@ -74,11 +78,17 @@ def test_sample(dist, num_samples):
 
 def test_context_error_log_prob(dist):
     """Assert an error is raised if log_prob is called and is not None."""
-    with pytest.raises(NotImplementedError, match="Context is not supported by MultidimensionalUniform!"):
+    with pytest.raises(
+        NotImplementedError,
+        match="Context is not supported by MultidimensionalUniform!",
+    ):
         MultivariateUniform._log_prob(dist, torch.ones(1), torch.ones(1))
 
 
 def test_context_error_sample(dist):
     """Assert an error is raised if sample is called and context is not None."""
-    with pytest.raises(NotImplementedError, match="Context is not supported by MultidimensionalUniform!"):
+    with pytest.raises(
+        NotImplementedError,
+        match="Context is not supported by MultidimensionalUniform!",
+    ):
         MultivariateUniform._sample(dist, 10, torch.ones(1))

--- a/tests/test_flows/test_nsf.py
+++ b/tests/test_flows/test_nsf.py
@@ -65,9 +65,10 @@ def test_coupling_nsf_forward_inverse():
 
 
 @pytest.mark.integration_test
+@pytest.mark.flaky(reruns=5)
 def test_coupling_nsf_uniform():
-    """Integration test to mke sure core functions work as intended with the \
-        unifrom latent space.
+    """Integration test to make sure core functions work as intended with the
+    uniform latent space.
     """
     flow = CouplingNSF(2, 2, distribution="uniform")
 
@@ -81,9 +82,9 @@ def test_coupling_nsf_uniform():
 
     # n_dims * log(1 - 0) = 0
     # So just Jacobian
-    expceted_log_prob = log_j.numpy()
+    expected_log_prob = log_j.numpy()
 
     np.testing.assert_array_almost_equal(x, x_inv)
     np.testing.assert_array_almost_equal(log_j, -log_j_inv)
-    np.testing.assert_array_equal(log_prob, expceted_log_prob)
+    np.testing.assert_array_equal(log_prob, expected_log_prob)
     assert x_out.shape == (10, 2)

--- a/tests/test_flows/test_nsf.py
+++ b/tests/test_flows/test_nsf.py
@@ -28,3 +28,28 @@ def test_coupling_nsf_forward_inverse():
 
     np.testing.assert_array_almost_equal(x, x_out)
     np.testing.assert_array_almost_equal(log_prob, -log_prob_inv)
+
+
+@pytest.mark.integration_test
+def test_coupling_nsf_uniform():
+    """Integration test to mke sure core functions work as intended with the \
+        unifrom latent space.
+    """
+    flow = CouplingNSF(2, 2, distribution="uniform")
+
+    x = torch.rand(100, 2)
+
+    with torch.no_grad():
+        z, log_j = flow.forward(x)
+        x_inv, log_j_inv = flow.inverse(z)
+        log_prob = flow.log_prob(x)
+        x_out = flow.sample(10)
+
+    # n_dims * log(1 - 0) = 0
+    # So just Jacobian
+    expceted_log_prob = log_j.numpy()
+
+    np.testing.assert_array_almost_equal(x, x_inv)
+    np.testing.assert_array_almost_equal(log_j, -log_j_inv)
+    np.testing.assert_array_equal(log_prob, expceted_log_prob)
+    assert x_out.shape == (10, 2)


### PR DESCRIPTION
Add a multivariate uniform distribution for use with the neural spline flows and add an option to use it to the `CouplingNSF`.

**To-Do**
- [x] More testing
- [x] Changelog