### PR TITLE
Update black version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 22.6.0
+  rev: 23.1.0
   hooks:
   - id: black
     language_version: python3

--- a/src/glasflow/flows/coupling.py
+++ b/src/glasflow/flows/coupling.py
@@ -67,7 +67,6 @@ class CouplingFlow(Flow):
         mask=None,
         **kwargs,
     ):
-
         if not issubclass(transform_class, CouplingTransform):
             raise RuntimeError(
                 "Transform class does not inherit from `CouplingTransform`"

--- a/tests/test_flows/test_nsf.py
+++ b/tests/test_flows/test_nsf.py
@@ -29,7 +29,6 @@ def test_init_uniform_distribution():
     ) as mock_dist, patch(
         "glasflow.flows.nsf.CouplingFlow.__init__"
     ) as mock_init:
-
         CouplingNSF(
             n_inputs=2,
             n_transforms=2,


### PR DESCRIPTION
Update black to the first version for 2023 to match the version in the CI.

This has a couple of minor style changes which are described here: https://github.com/psf/black/releases/tag/23.1.0.

**Note:** developers should update their pre-commits.