### PR TITLE
Rework affine coupling transform

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ target-version = ["py36", "py37", "py38", "py39"]
 extend-exclude = "submodules"
 
 [tool.pytest.ini_options]
+addopts = [
+    "--import-mode=importlib",
+]
 testpaths = [
     "tests"
 ]

--- a/src/glasflow/transforms/coupling.py
+++ b/src/glasflow/transforms/coupling.py
@@ -30,7 +30,7 @@ class AffineCouplingTransform(BaseAffineCouplingTransform):
         transform_net_create_fn,
         unconditional_transform=None,
         scaling_method=None,
-        scale_activation=None,
+        scale_activation="log3",
         **kwargs,
     ):
         if scaling_method is not None:

--- a/src/glasflow/transforms/coupling.py
+++ b/src/glasflow/transforms/coupling.py
@@ -1,58 +1,49 @@
 # -*- coding: utf-8 -*-
 """Alternative implementations of coupling transforms"""
+import warnings
+
 from glasflow.nflows.transforms.coupling import (
     AffineCouplingTransform as BaseAffineCouplingTransform,
 )
 import torch.nn.functional as F
 
+from .utils import get_scale_activation
+
 
 class AffineCouplingTransform(BaseAffineCouplingTransform):
-    """Modified affine coupling transform that has different scaling options.
+    """Modified affine coupling transform that includes predefined scale
+    activations.
 
-    Adds the option to use different ranges for the scaling parameters. In
-    `nflows` the scale is limited to [0, 1.001]. This method adds the `'wide'`
-    option where the scale is limited to [0, 3].
+    Adds the option specify `scale_activation` as a string which is passed to
+    `get_scale_activation` to get the corresponding function. Also supports
+    specifying the function instead of string.
     """
-
-    _allowed_scaling_methods = ["nflows", "wide"]
 
     def __init__(
         self,
         mask,
         transform_net_create_fn,
         unconditional_transform=None,
-        scaling_method="nflows",
+        scaling_method=None,
+        scale_activation=None,
         **kwargs,
     ):
+        if scaling_method is not None:
+            warnings.warn(
+                (
+                    "scaling_method is deprecated and will be removed in a "
+                    "future release. Use `scale_activation` instead."
+                ),
+                FutureWarning,
+            )
+            scale_activation = scaling_method
+
+        scale_activation = get_scale_activation(scale_activation)
+
         super().__init__(
             mask,
             transform_net_create_fn,
             unconditional_transform=unconditional_transform,
+            scale_activation=scale_activation,
             **kwargs,
         )
-
-        if scaling_method in self._allowed_scaling_methods:
-            self.scaling_method = scaling_method
-        else:
-            raise ValueError(
-                f"Invalid scaling method: {scaling_method}. "
-                f"Choose from: {self._allowed_scaling_methods}."
-            )
-
-    def _scale_and_shift_wide(self, transform_params):
-        unconstrained_scale = transform_params[
-            :, self.num_transform_features :, ...
-        ]
-        shift = transform_params[:, : self.num_transform_features, ...]
-        scale = (F.softplus(unconstrained_scale) + 1e-3).clamp(0, 3)
-        return scale, shift
-
-    def _scale_and_shift(self, transform_params):
-        if self.scaling_method == "nflows":
-            return super()._scale_and_shift(transform_params)
-        elif self.scaling_method == "wide":
-            return self._scale_and_shift_wide(transform_params)
-        else:
-            raise RuntimeError(
-                f"Unknown scaling method: {self.scaling_method}"
-            )

--- a/src/glasflow/transforms/utils.py
+++ b/src/glasflow/transforms/utils.py
@@ -17,14 +17,20 @@ SCALE_ACTIVATIONS = dict(
 def get_scale_activation(activation: Union[str, Callable]) -> Callable:
     """Get the scale activation function.
 
-    If `activation` is not a string, then it is returned.
+    If `activation` is not a string, then it is returned. If `activation` is
+    a string of the form `logN` where `N` is a number, then the activation is
+    `exp(2N * (sigmoid(x) - 0.5))`. In the current implementation this
+    corresponds to estimating the log-scale.
     """
     if not isinstance(activation, str):
         return activation
     elif activation in SCALE_ACTIVATIONS:
         return SCALE_ACTIVATIONS.get(activation)
+    elif activation[:3] == "log":
+        scale = float(activation[3:])
+        return lambda x: torch.exp(2 * scale * (torch.sigmoid(x) - 0.5))
     else:
         raise ValueError(
             f"Unknown activation: {activation}. "
-            f"Choose from: {SCALE_ACTIVATIONS}"
+            f"Choose from: {SCALE_ACTIVATIONS} or logN, where N is a number."
         )

--- a/src/glasflow/transforms/utils.py
+++ b/src/glasflow/transforms/utils.py
@@ -1,0 +1,30 @@
+"""Utilities for the transforms submodule"""
+from typing import Callable, Union
+import torch
+import torch.nn.functional as F
+
+
+SCALE_ACTIVATIONS = dict(
+    nflows=lambda x: torch.sigmoid(x + 2) + 1e-3,
+    nflows_general=lambda x: (F.softplus(x) + 1e-3).clamp(0, 3),
+    wide=lambda x: (F.softplus(x) + 1e-3).clamp(0, 3),
+    log1=lambda x: torch.exp(2 * (torch.sigmoid(x) - 0.5)),
+    log2=lambda x: torch.exp(4 * (torch.sigmoid(x) - 0.5)),
+    log3=lambda x: torch.exp(6 * (torch.sigmoid(x) - 0.5)),
+)
+
+
+def get_scale_activation(activation: Union[str, Callable]) -> Callable:
+    """Get the scale activation function.
+
+    If `activation` is not a string, then it is returned.
+    """
+    if not isinstance(activation, str):
+        return activation
+    elif activation in SCALE_ACTIVATIONS:
+        return SCALE_ACTIVATIONS.get(activation)
+    else:
+        raise ValueError(
+            f"Unknown activation: {activation}. "
+            f"Choose from: {SCALE_ACTIVATIONS}"
+        )

--- a/tests/test_flows/test_realnvp.py
+++ b/tests/test_flows/test_realnvp.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import torch
 from glasflow.flows import RealNVP
+from glasflow.transforms.utils import SCALE_ACTIVATIONS
 
 import pytest
 
@@ -20,5 +21,17 @@ def test_realnvp_wide_scale():
     z, log_j = flow.forward(x)
     x_out, log_j_out = flow.inverse(z)
 
+    assert torch.allclose(x, x_out)
+    assert torch.allclose(log_j, -log_j_out)
+
+
+@pytest.mark.integration_test
+@pytest.mark.flaky(reruns=5)
+@pytest.mark.parametrize("scale_activation", list(SCALE_ACTIVATIONS.keys()))
+def test_realnvp_scale_activation(scale_activation):
+    flow = RealNVP(2, 2, scale_activation=scale_activation)
+    x = torch.randn(10, 2)
+    z, log_j = flow.forward(x)
+    x_out, log_j_out = flow.inverse(z)
     assert torch.allclose(x, x_out)
     assert torch.allclose(log_j, -log_j_out)

--- a/tests/test_flows/test_realnvp.py
+++ b/tests/test_flows/test_realnvp.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import torch
+from glasflow import USE_NFLOWS
 from glasflow.flows import RealNVP
 from glasflow.transforms.utils import SCALE_ACTIVATIONS
 
@@ -35,3 +36,16 @@ def test_realnvp_scale_activation(scale_activation):
     x_out, log_j_out = flow.inverse(z)
     assert torch.allclose(x, x_out)
     assert torch.allclose(log_j, -log_j_out)
+
+
+@pytest.mark.skipif(
+    USE_NFLOWS is False, reason="Test only applies when using nflows"
+)
+def test_affine_coupling_warning_nflows(caplog):
+    """Assert a warning is printed if using `scale_activation` with nflows"""
+    RealNVP(2, 2, scale_activation="log1")
+    assert "Trying without `scale_activation`" in caplog.text
+    assert (
+        "Using affine coupling transform without `scale_activation`"
+        in caplog.text
+    )

--- a/tests/test_flows/test_realnvp.py
+++ b/tests/test_flows/test_realnvp.py
@@ -13,6 +13,12 @@ def test_coupling_flow_init(volume_preserving):
     RealNVP(2, 2, volume_preserving=volume_preserving)
 
 
+def test_real_nvp_defaults():
+    flow = RealNVP(2, 2)
+    x = torch.randn(10, 2)
+    flow.forward(x)
+
+
 @pytest.mark.integration_test
 @pytest.mark.flaky(reruns=5)
 def test_realnvp_wide_scale():

--- a/tests/test_transforms/test_coupling_transforms.py
+++ b/tests/test_transforms/test_coupling_transforms.py
@@ -1,90 +1,35 @@
 # -*- coding: utf-8 -*-
 from glasflow.transforms.coupling import AffineCouplingTransform
 import pytest
-import torch
-from unittest.mock import MagicMock, create_autospec, patch
+from unittest.mock import create_autospec, patch
 
 
 @pytest.fixture
 def affine_transform():
-    transform = create_autospec(AffineCouplingTransform)
-    transform.num_transform_features = 2
-    transform._allowed_scaling_methods = ["nflows", "wide"]
-    return transform
+    return create_autospec(AffineCouplingTransform)
 
 
-@pytest.mark.parametrize("scaling_method", ["nflows", "wide"])
+@patch(
+    "glasflow.transforms.coupling.get_scale_activation",
+    return_value="act_fn",
+)
 @patch("glasflow.nflows.transforms.coupling.AffineCouplingTransform.__init__")
-def test_affine_init(mock, affine_transform, scaling_method):
-    """Assert the init method pass inputs to the parent class"""
+def test_affine_coupling_init(mock_init, mock_get, affine_transform):
     mask = [1, -1]
-    fn = "function"
-    ut = False
+    create_fn = object()
+
     AffineCouplingTransform.__init__(
         affine_transform,
         mask,
-        fn,
-        unconditional_transform=ut,
-        scaling_method=scaling_method,
+        create_fn,
+        unconditional_transform=None,
+        scale_activation="test",
     )
-    mock.assert_called_once_with(mask, fn, unconditional_transform=ut)
-    assert affine_transform.scaling_method == scaling_method
 
-
-@patch("glasflow.nflows.transforms.coupling.AffineCouplingTransform.__init__")
-def test_affine_init_invalid_scaling(mock, affine_transform):
-    """Assert an error is raised if an invalid scaling method is passed"""
-    mask = [1, -1]
-    fn = "function"
-    ut = False
-    with pytest.raises(ValueError) as excinfo:
-        AffineCouplingTransform.__init__(
-            affine_transform,
-            mask,
-            fn,
-            unconditional_transform=ut,
-            scaling_method="test",
-        )
-    mock.assert_called_once_with(mask, fn, unconditional_transform=ut)
-    assert "Invalid scaling method" in str(excinfo.value)
-
-
-def test_scale_and_shift_wide_transform(affine_transform):
-    """Assert the range of returned values is [0, 3]."""
-    params = torch.Tensor([[1, 2, 2, 6], [3, 4, -3, -100]])
-    scale, shift = AffineCouplingTransform._scale_and_shift_wide(
-        affine_transform, params
+    mock_get.assert_called_once_with("test")
+    mock_init.assert_called_once_with(
+        mask,
+        create_fn,
+        unconditional_transform=None,
+        scale_activation="act_fn",
     )
-    print(scale, shift)
-    assert torch.equal(shift, torch.Tensor([[1, 2], [3, 4]]))
-    assert torch.all(scale >= 0)
-    assert scale[0, 1] == 3.0
-
-
-def test_scale_and_shift_nflows(affine_transform):
-    """Assert the correct scale and shift is callled for nflows"""
-    params = "params"
-    affine_transform.scaling_method = "nflows"
-    with patch(
-        "glasflow.nflows.transforms.coupling.AffineCouplingTransform._scale_and_shift"
-    ) as mock:
-        AffineCouplingTransform._scale_and_shift(affine_transform, params)
-    mock.assert_called_once_with(params)
-
-
-def test_scale_and_shift_wide(affine_transform):
-    """Assert the correct scale and shift is callled for wide"""
-    params = "params"
-    affine_transform.scaling_method = "wide"
-    affine_transform._scale_and_shift_wide = MagicMock()
-    AffineCouplingTransform._scale_and_shift(affine_transform, params)
-    affine_transform._scale_and_shift_wide.assert_called_once_with(params)
-
-
-def test_scale_and_shift_invalid_method(affine_transform):
-    """Assert an error is raised if an invalid scaling method is used."""
-    params = "params"
-    affine_transform.scaling_method = "test"
-    with pytest.raises(RuntimeError) as excinfo:
-        AffineCouplingTransform._scale_and_shift(affine_transform, params)
-    assert "Unknown scaling method" in str(excinfo.value)

--- a/tests/test_transforms/test_coupling_transforms.py
+++ b/tests/test_transforms/test_coupling_transforms.py
@@ -33,3 +33,20 @@ def test_affine_coupling_init(mock_init, mock_get, affine_transform):
         unconditional_transform=None,
         scale_activation="act_fn",
     )
+
+
+def test_affine_coupling_invalid(affine_transform):
+    """Assert an error is raised that is not `scale_activation`"""
+    mask = [1, -1]
+    create_fn = object()
+
+    with pytest.raises(
+        TypeError,
+        match=r"unexpected keyword argument 'invalid_test'",
+    ):
+        AffineCouplingTransform.__init__(
+            affine_transform,
+            mask,
+            create_fn,
+            invalid_test=None,
+        )

--- a/tests/test_transforms/test_utils.py
+++ b/tests/test_transforms/test_utils.py
@@ -10,7 +10,7 @@ def test_get_scale_activation_str(name):
 
 def test_get_scale_activation_fn():
     def fn(x):
-        return torch.sigmod(x)
+        return torch.sigmoid(x)
 
     assert get_scale_activation(fn) is fn
 

--- a/tests/test_transforms/test_utils.py
+++ b/tests/test_transforms/test_utils.py
@@ -15,6 +15,13 @@ def test_get_scale_activation_fn():
     assert get_scale_activation(fn) is fn
 
 
+def test_get_scale_activation_log():
+    fn = get_scale_activation("log10")
+    inputs = torch.tensor([-torch.inf, 0.0, torch.inf])
+    expected = torch.exp(torch.tensor([-10.0, 0.0, 10.0]))
+    assert torch.equal(fn(inputs), expected)
+
+
 def test_get_scale_activation_invalid():
     with pytest.raises(ValueError, match=r"Unknown activation: .*"):
         get_scale_activation("invalid")

--- a/tests/test_transforms/test_utils.py
+++ b/tests/test_transforms/test_utils.py
@@ -1,0 +1,20 @@
+from glasflow.transforms.utils import SCALE_ACTIVATIONS, get_scale_activation
+import torch
+import pytest
+
+
+@pytest.mark.parametrize("name", list(SCALE_ACTIVATIONS.keys()))
+def test_get_scale_activation_str(name):
+    assert get_scale_activation(name) is SCALE_ACTIVATIONS[name]
+
+
+def test_get_scale_activation_fn():
+    def fn(x):
+        return torch.sigmod(x)
+
+    assert get_scale_activation(fn) is fn
+
+
+def test_get_scale_activation_invalid():
+    with pytest.raises(ValueError, match=r"Unknown activation: .*"):
+        get_scale_activation("invalid")


### PR DESCRIPTION
Following from https://github.com/uofgravity/glasflow/pull/51, this PR reworks `AffineCouplingTransform` to use `scale_activation` instead of `scaling_method` and to include a set of predefined activations.

Once this is in, I plan to release v0.3.0

**To-Do**
- [x] Agree on default
- [x] Consider any extra activations