### PR TITLE
Set default coupling activation to nflows_general

### DIFF
--- a/src/glasflow/transforms/coupling.py
+++ b/src/glasflow/transforms/coupling.py
@@ -30,7 +30,7 @@ class AffineCouplingTransform(BaseAffineCouplingTransform):
         transform_net_create_fn,
         unconditional_transform=None,
         scaling_method=None,
-        scale_activation="log3",
+        scale_activation="nflows_general",
         **kwargs,
     ):
         if scaling_method is not None:


### PR DESCRIPTION
From some basic tests, it's not clear to me that `log3` is any better than `nflows_general`. So I'm going to change the default to `nflows_general` for consistency. We can always change this in a later release.