### PR TITLE
CI: downgrade numpy<2.0 on windows

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,6 +38,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
+    - name: Downgrade numpy
+      if: runner.os == 'Windows'
+      run: |
+        python -m pip install "numpy<2.0"
     - name: Optionally install nflows
       if: ${{ matrix.use-nflows }}
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
+    - name: Downgrade numpy
+      if: runner.os == 'Windows'
+      run: |
+        python -m pip install "numpy<2.0"
     - name: Optionally install nflows
       if: ${{ matrix.use-nflows }}
       run: |

--- a/.github/workflows/tests_nflows_fork.yml
+++ b/.github/workflows/tests_nflows_fork.yml
@@ -33,6 +33,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[nflows-test]
+    - name: Downgrade numpy
+      if: runner.os == 'Windows'
+      run: |
+        python -m pip install "numpy<2.0"
     - name: Test with pytest
       run: |
         python -m pytest submodules/nflows


### PR DESCRIPTION
The CI seems to be failing because torch + numpy 2.0 is broken on windows. Rather than change the dependencies, I've temporarily added a line to downgrade numpy in the CI.